### PR TITLE
fixed parsing the timezone when reading API response

### DIFF
--- a/src/main/java/com/ciscospark/Client.java
+++ b/src/main/java/com/ciscospark/Client.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
  */
 class Client {
     private static final String TRACKING_ID = "TrackingID";
-    public static final String ISO8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final String ISO8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
     final URI baseUri;
 


### PR DESCRIPTION
We parse the timezone in the API response wrong. This is before the fix when I query any resource like people/me
people/me

API response
 "created": "2017-10-26T23:11:32.021Z",
  "lastActivity": "2019-02-22T19:03:25.661Z",
  "status": "inactive",


 SDK response
created: Thu Oct 26 23:11:32 PDT 2017
lastActivity: Fri Feb 22 19:03:25 PST 2019


This is after the fix with the correct translation of Zulu time to local time
Thu Oct 26 16:11:32 PDT 2017
Fri Feb 22 11:03:25 PST 2019